### PR TITLE
fix: add Microsecond and Nanosecond to TimeValueComparer and DateTimeValueComparer

### DIFF
--- a/src/Pure.Primitives.Abstractions.EFCore.ValueComparers/DateTimeValueComparer.cs
+++ b/src/Pure.Primitives.Abstractions.EFCore.ValueComparers/DateTimeValueComparer.cs
@@ -19,19 +19,25 @@ public sealed class DateTimeValueComparer : ValueComparer<IDateTime>
                     && a.Minute.NumberValue == b.Minute.NumberValue
                     && a.Second.NumberValue == b.Second.NumberValue
                     && a.Millisecond.NumberValue == b.Millisecond.NumberValue
+                    && a.Microsecond.NumberValue == b.Microsecond.NumberValue
+                    && a.Nanosecond.NumberValue == b.Nanosecond.NumberValue
                 ),
-            v =>
-                v == null
-                    ? 0
-                    : HashCode.Combine(
-                        v.Year.NumberValue,
-                        v.Month.NumberValue,
-                        v.Day.NumberValue,
-                        v.Hour.NumberValue,
-                        v.Minute.NumberValue,
-                        v.Second.NumberValue,
-                        v.Millisecond.NumberValue
-                    )
+            v => v == null ? 0 : ComputeHash(v)
         )
     { }
+
+    private static int ComputeHash(IDateTime v)
+    {
+        HashCode hash = new();
+        hash.Add(v.Year.NumberValue);
+        hash.Add(v.Month.NumberValue);
+        hash.Add(v.Day.NumberValue);
+        hash.Add(v.Hour.NumberValue);
+        hash.Add(v.Minute.NumberValue);
+        hash.Add(v.Second.NumberValue);
+        hash.Add(v.Millisecond.NumberValue);
+        hash.Add(v.Microsecond.NumberValue);
+        hash.Add(v.Nanosecond.NumberValue);
+        return hash.ToHashCode();
+    }
 }

--- a/src/Pure.Primitives.Abstractions.EFCore.ValueComparers/TimeValueComparer.cs
+++ b/src/Pure.Primitives.Abstractions.EFCore.ValueComparers/TimeValueComparer.cs
@@ -16,6 +16,8 @@ public sealed class TimeValueComparer : ValueComparer<ITime>
                     && a.Minute.NumberValue == b.Minute.NumberValue
                     && a.Second.NumberValue == b.Second.NumberValue
                     && a.Millisecond.NumberValue == b.Millisecond.NumberValue
+                    && a.Microsecond.NumberValue == b.Microsecond.NumberValue
+                    && a.Nanosecond.NumberValue == b.Nanosecond.NumberValue
                 ),
             v =>
                 v == null
@@ -24,7 +26,9 @@ public sealed class TimeValueComparer : ValueComparer<ITime>
                         v.Hour.NumberValue,
                         v.Minute.NumberValue,
                         v.Second.NumberValue,
-                        v.Millisecond.NumberValue
+                        v.Millisecond.NumberValue,
+                        v.Microsecond.NumberValue,
+                        v.Nanosecond.NumberValue
                     )
         )
     { }


### PR DESCRIPTION
Fixes #35

Both comparers were stopping at `Millisecond`, leaving `Microsecond` and `Nanosecond` out of equality check and hash code. `DateTimeValueComparer` uses a private static `ComputeHash` method with `HashCode.Add()` to work around the 8-argument limit of `HashCode.Combine`.