### PR TITLE
Update package validation baseline to 0.1.0-preview.0.1.1

### DIFF
--- a/src/Pure.Primitives.Abstractions.EFCore.ValueComparers/Pure.Primitives.Abstractions.EFCore.ValueComparers.csproj
+++ b/src/Pure.Primitives.Abstractions.EFCore.ValueComparers/Pure.Primitives.Abstractions.EFCore.ValueComparers.csproj
@@ -6,7 +6,7 @@
     <LangVersion>latest</LangVersion>
     <IsAotCompatible>true</IsAotCompatible>
     <EnablePackageValidation>true</EnablePackageValidation>
-    <PackageValidationBaselineVersion>0.1.0-preview.0.1.0</PackageValidationBaselineVersion>
+    <PackageValidationBaselineVersion>0.1.0-preview.0.1.1</PackageValidationBaselineVersion>
   </PropertyGroup>
   <PropertyGroup>
     <PackageId>Pure.Primitives.Abstractions.EFCore.ValueComparers</PackageId>


### PR DESCRIPTION
Bump `PackageValidationBaselineVersion` from `0.1.0-preview.0.1.0` to `0.1.0-preview.0.1.1` following the successful publish.